### PR TITLE
build: Update GNOME runtime to 40 & drop libhandy dep

### DIFF
--- a/com.github.gi_lom.dialect.json
+++ b/com.github.gi_lom.dialect.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.gi_lom.dialect",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.38",
+    "runtime-version" : "40",
     "sdk" : "org.gnome.Sdk",
     "command" : "dialect",
     "finish-args" : [
@@ -15,29 +15,6 @@
     ],
     "modules" : [
         "pypi-dependencies.json",
-        {
-            "name" : "libhandy",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "-Dgtk_doc=false",
-                "-Dtests=false",
-                "-Dexamples=false",
-                "-Dvapi=false",
-                "-Dglade_catalog=disabled"
-            ],
-            "cleanup" : [
-                "/include",
-                "/lib/pkgconfig"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/libhandy.git",
-                    "tag" : "1.1.90",
-                    "commit" : "89a1610b62533c9d6c5267cfac0108e724df25ba"
-                }
-            ]
-        },
         {
             "name" : "dialect",
             "builddir" : true,


### PR DESCRIPTION
libhandy now is a part of new GNOME 40 runtime.